### PR TITLE
K modes

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,8 +1,7 @@
 
 
 """
-Represent an normal ordered boson operator
-Each key is a
+Represent an normal ordered boson operator `o(N)` where `N` is the number of modes.
 """
 mutable struct Operator
     N::Int


### PR DESCRIPTION
added functionality for mode multiplication for operators of N length. But currently can multiply with two conditions: (1) operators only have one occupation on one site, (2) they are occupied on the same site.